### PR TITLE
Making Options Optionals in play

### DIFF
--- a/src/DisTube.ts
+++ b/src/DisTube.ts
@@ -140,7 +140,7 @@ export class DisTube extends TypedEmitter<DisTubeEvents> {
   async play(
     voiceChannel: VoiceBasedChannel,
     song: string | Song | SearchResult | Playlist | null,
-    options: {
+    options?: {
       skip?: boolean;
       unshift?: boolean;
       member?: GuildMember;
@@ -167,12 +167,12 @@ export class DisTube extends TypedEmitter<DisTubeEvents> {
   async play(
     message: Message<true>,
     song: string | Song | SearchResult | Playlist,
-    options: { skip?: boolean; unshift?: boolean; metadata?: any },
+    options?: { skip?: boolean; unshift?: boolean; metadata?: any },
   ): Promise<void>;
   async play(
     voiceChannel: Message<true> | VoiceBasedChannel,
     song: string | Song | SearchResult | Playlist | null,
-    options: {
+    options?: {
       skip?: boolean;
       unshift?: boolean;
       member?: GuildMember;


### PR DESCRIPTION
In play() function, options parameter should be optional, as all the options are. So then you won't force the user to provide an empty object for options