### PR TITLE
feat: Listen to voiceStateUpdate event without leaveOnEmpty being true

### DIFF
--- a/src/DisTube.ts
+++ b/src/DisTube.ts
@@ -635,8 +635,7 @@ export default DisTube;
  */
 
 /**
- * Emitted when there is no user in the voice channel,
- * {@link DisTubeOptions}.leaveOnEmpty is `true` and there is a playing queue.
+ * Emitted when there is no user in the voice channel and there is a playing queue.
  *
  * If there is no playing queue (stopped and {@link DisTubeOptions}.leaveOnStop is `false`),
  * it will leave the channel without emitting this event.

--- a/src/type.ts
+++ b/src/type.ts
@@ -101,7 +101,7 @@ export type Filters = Record<string, string>;
  * @prop {Filters} [customFilters] Override {@link defaultFilters} or add more ffmpeg filters.
  * @prop {ytdl.getInfoOptions} [ytdlOptions] `ytdl-core` get info options
  * @prop {number} [searchCooldown=60] Built-in search cooldown in seconds (When searchSongs is bigger than 0)
- * @prop {number} [emptyCooldown=60] Built-in leave on empty cooldown in seconds (When leaveOnEmpty is true)
+ * @prop {number} [emptyCooldown=60] Built-in leave on empty cooldown in seconds
  * @prop {boolean} [nsfw=false] Whether or not playing age-restricted content
  * and disabling safe search in non-NSFW channel.
  * @prop {boolean} [emitAddListWhenCreatingQueue=true] Whether or not emitting `addList` event when creating a new Queue


### PR DESCRIPTION
This change offers more possibilities with empty event without having to leave the voice channel. For example: send a message, stop the current queue, etc.
