### PR TITLE
Fix: Rename variable in Major-Upgrade-Guide.md

### DIFF
--- a/wiki/Major-Upgrade-Guide.md
+++ b/wiki/Major-Upgrade-Guide.md
@@ -56,7 +56,7 @@ ytPlugin.search(query, { type: "video", limit: 5, safeSearch: true }).then(conso
 - const ageRestricted = song.age_restricted
 + const ageRestricted = song.ageRestricted
 - const duration = song.duration
-+ const streamURL = song.stream.playFromSource ? song.duration : song.stream.song.duration
++ const duration = song.stream.playFromSource ? song.duration : song.stream.song.duration
 - const streamURL = song.streamURL
 + const streamURL = song.stream.playFromSource ? song.stream.url : song.stream.song.stream.url
 ```


### PR DESCRIPTION
In the diff part of the Migrate from v4 to v5, I noticed there were 2 variables with the same name `streamURL`. Given the context, it might be mistyped so I have renamed it to prevent confusion for the reader.