### PR TITLE
fix: distube crash when trying to add a song to the queue while the queue is in pause state

### DIFF
--- a/src/core/manager/QueueManager.ts
+++ b/src/core/manager/QueueManager.ts
@@ -143,7 +143,7 @@ export class QueueManager extends GuildIdManager<Queue> {
    * @param emitPlaySong  - Whether or not emit {@link Events.PLAY_SONG} event
    */
   async playSong(queue: Queue, emitPlaySong = true) {
-    if (!queue) return;
+    if (!queue || queue.voice.audioPlayer.state.status == "paused") return;
     if (queue.stopped || !queue.songs.length) {
       queue.stop();
       return;


### PR DESCRIPTION
when trying to add a song while the queue is paused the whole application crashes because it tries to open a new stream for the new song but the old one is still using it